### PR TITLE
TydiLang output and other updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /output
 /venv
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /output
+/venv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# JSON-TIL
+
+JSON-TIL is a tool for automating the design process for parsing JSON streams on FPGAs. It uses [Tydi-JSON](https://github.com/jhaenen/tydi-json) components, which implement JSON parsing components with Tydi streaming interfaces. JSON-TIL simplifies the process of assembling and configuring the parsing components required for specific JSON schema streams.
+
+## Features
+
+- **Automatic JSON Parsing Design**: JSON-TIL can analyze a sample JSON stream and automatically assemble the necessary parsing components.
+- **Tydi-JSON Component Tree Visualizer**: Provides a visualization of the assembled Tydi-JSON component tree for better understanding and debugging.
+- **TIL Generator**: Outputs a [Tydi Intermediate Language (TIL)](https://github.com/matthijsr/til-vhdl/) file, representing the parsing logic for the JSON stream.
+- **TydiLang Generator**: In addition to TIL, JSON-TIL now supports generating [TydiLang](https://github.com/twoentartian/tydi-lang-2) (`.td`) files. TL can automatically insert stream duplicators, addressing the biggest issue in the original workflow.
+
+## Workflow
+
+1. **Input**: Provide a sample JSON stream to JSON-TIL.
+2. **JSON Analysis**: The tool analyzes the JSON structure and identifies required parsing components.
+3. **Component Assembly**: Automatically assembles and connects Tydi-JSON parsing components.
+4. **Output**: Generates a TIL file and a TydiLang file that represent the parsing logic for the JSON stream.
+5. **HDL Generation**:
+   - Use the `til` file with [TIL-VHDL](https://github.com/matthijsr/til-vhdl/) to generate a VHDL project for FPGA implementation.
+   - Use the `td` file with [TydiLang](https://github.com/twoentartian/tydi-lang-2) and [Tydi-lang-2-Chisel](https://github.com/ccromjongh/tydi-lang-2-chisel) to generate Chisel code and subsequently Verilog output for the FPGA implementation. See [Tydi-Chisel](https://github.com/abs-tudelft/Tydi-Chisel) for details.
+
+## Usage
+
+To use JSON-TIL, clone the repository and build the project:
+
+```bash
+git clone https://github.com/your-org/json-til.git
+cd json-til
+cargo build --release
+```
+
+## Requirements
+- Rust (latest stable version)
+- Python 3 (used by `pyo3`)
+- TIL-VHDL or TydiLang for usage of the output
+
+## Citing JSON-TIL
+If you use JSON-TIL in your research, please cite it using the following BibTeX entry:
+```tex
+@article{haenen_json-til_2023,
+    title = {{JSON}-{TIL}: {A} tool for generating/reducing boilerplate when creating and composing streaming {JSON} dataflow accelerators using {Tydi} interfaces},
+    url = {https://github.com/jhaenen/JSON_hierachy/blob/master/TIL_JSON.pdf},
+    author = {Haenen, Jasper},
+    month = jan,
+    year = {2023},
+}
+```
+
+## License
+This project is licensed under the Apache 2.0 License. See the [LICENSE](LICENSE) file for more details.

--- a/src/analysis/analyzer/analysis.rs
+++ b/src/analysis/analyzer/analysis.rs
@@ -54,7 +54,7 @@ impl Analyzer {
                             Value::new(
                                 &self.name_reg.register("string_parser", outer_nesting),
                                 JsonType::String,
-                                outer_nesting, // Strings don't increase the nesting level since the input is a string
+                                outer_nesting+1, // Strings don't increase the nesting level since the input is a string
                             )
                         )
                     ), 

--- a/src/analysis/analyzer/type_manager.rs
+++ b/src/analysis/analyzer/type_manager.rs
@@ -81,6 +81,17 @@ impl StreamType {
 
         format!("type {}{} = {};\n\n", self.get_name(), dim_str, type_params)
     }
+
+    pub fn get_td_type_def_string(&self, gen_params: &GeneratorParams) -> String {
+        let type_params = self.get_type_params(gen_params);
+
+        let dim_str = match type_params.dimensionality {
+            Dimensionality::Fixed(_) => "".to_string(),
+            Dimensionality::Generic => format!("<{}: dimensionality = 2>", Dimensionality::Generic),
+        };
+
+        format!("{} = {};\n\n", self.get_name(), type_params.td())
+    }
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
@@ -101,6 +112,22 @@ impl StreamParams {
             synchronicity,
             complexity,
         }
+    }
+
+    pub fn td(&self) -> String {
+        format!(
+"Stream(
+    Bit({}),
+    throughput: {}.0,
+    dimension: {},
+    synchronicity: \"{:?}\",
+    complexity: {},
+)",
+        self.data_bits,
+        self.throughput,
+        self.dimensionality,
+        self.synchronicity,
+        self.complexity,)
     }
 }
 

--- a/src/analysis/analyzer/type_manager.rs
+++ b/src/analysis/analyzer/type_manager.rs
@@ -90,7 +90,7 @@ impl StreamType {
             Dimensionality::Generic => format!("<{}: dimensionality = 2>", Dimensionality::Generic),
         };
 
-        format!("{} = {};\n\n", self.get_name(), type_params.td())
+        format!("\n{} = {};\n", self.get_name(), type_params.td())
     }
 }
 
@@ -118,10 +118,10 @@ impl StreamParams {
         format!(
 "Stream(
     Bit({}),
-    throughput: {}.0,
-    dimension: {},
-    synchronicity: \"{:?}\",
-    complexity: {},
+    throughput = {}.0,
+    dimension = {},
+    synchronicity = \"{:?}\",
+    complexity = {}
 )",
         self.data_bits,
         self.throughput,

--- a/src/analysis/generator.rs
+++ b/src/analysis/generator.rs
@@ -44,13 +44,16 @@ impl Generator {
         std::fs::create_dir_all(format!("{}/src", proj_dir)).unwrap();
 
         // Create the file
-        let mut file = std::fs::File::create(format!("{}/src/{}.til", proj_dir, self.gen_params.project_name)).unwrap();
+        let mut til_file = std::fs::File::create(format!("{}/src/{}.til", proj_dir, self.gen_params.project_name)).unwrap();
+        let mut td_file = std::fs::File::create(format!("{}/src/{}.td", proj_dir, self.gen_params.project_name)).unwrap();
 
         use std::io::Write;
 
         let til = self.generate_til();
+        let td = self.generate_td();
 
-        file.write_fmt(format_args!("{}", til)).unwrap();
+        til_file.write_fmt(format_args!("{}", til)).unwrap();
+        td_file.write_fmt(format_args!("{}", td)).unwrap();
 
         // Generate the files
         let file_manager = self.analyzer.get_file_manager();

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -6,6 +6,7 @@ pub mod generator;
 pub mod analyzer;
 pub mod types;
 mod til;
+mod td;
 
 
 pub struct Generator {

--- a/src/analysis/td.rs
+++ b/src/analysis/td.rs
@@ -6,7 +6,7 @@ use super::{Generator, td};
 
  fn generate_namespace_def(namespace: &str) -> String {
     let mut prelude = String::new();
-    prelude.push_str(&format!("package {};\n", namespace));
+    prelude.push_str(&format!("package {};\n\n", namespace.replace("::", "_")));
 
     prelude
 }
@@ -26,9 +26,13 @@ impl Generator {
 
         let (type_defs, stream_defs) = self.analyzer.get_definitions();
 
+        td.push_str("streamlet t <d: int> {");
+
         for type_def in type_defs {
             td.push_str(&type_def.get_td_type_def_string(&self.gen_params));
         }
+
+        td.push_str("}\n\n");
 
         for stream_def in stream_defs {
             td.push_str(&format!("{}\n\n", stream_def.td()));

--- a/src/analysis/td.rs
+++ b/src/analysis/td.rs
@@ -1,0 +1,44 @@
+use super::{Generator, td};
+
+/**********************************************************************************
+ * Set of functions to generate TD code from the analyzed definitions            *
+ **********************************************************************************/
+
+ fn generate_namespace_def(namespace: &str) -> String {
+    let mut prelude = String::new();
+    prelude.push_str(&format!("package {};\n", namespace));
+
+    prelude
+}
+
+fn generate_close_namespace() -> String {
+    let mut postlude = String::new();
+    postlude.push_str("\n");
+
+    postlude
+}
+
+impl Generator {
+    pub fn generate_td(&mut self) -> String {
+        let mut td = String::new();
+
+        td.push_str(&td::generate_namespace_def(&self.gen_params.namespace));
+
+        let (type_defs, stream_defs) = self.analyzer.get_definitions();
+
+        for type_def in type_defs {
+            td.push_str(&type_def.get_td_type_def_string(&self.gen_params));
+        }
+
+        for stream_def in stream_defs {
+            td.push_str(&format!("{}\n\n", stream_def.td()));
+        }
+
+        let top_component = self.analyzer.assemble_top_component().unwrap();
+        td.push_str(&top_component.td());
+
+        td.push_str(&td::generate_close_namespace());
+
+        td
+    }
+}

--- a/src/analysis/til.rs
+++ b/src/analysis/til.rs
@@ -6,7 +6,7 @@ use super::{Generator, til};
 
  fn generate_namespace_def(namespace: &str) -> String {
     let mut prelude = String::new();
-    prelude.push_str(&format!("namespace {} {{\n\t", namespace));
+    prelude.push_str(&format!("namespace {} {{\n    ", namespace));
 
     prelude
 }

--- a/src/analysis/types/signals.rs
+++ b/src/analysis/types/signals.rs
@@ -61,4 +61,29 @@ impl TilSignal {
             TilSignal::Output{dest_stream_name, ..} => dest_stream_name,
         }
     }
+
+    pub fn td(&self) -> String {
+        let mut signal = String::new();
+
+        // If the signal is from an instance, add the instance name
+        if let Some(source_inst_name) = self.get_source_inst_name() {
+            signal.push_str(&format!("\t{}.", source_inst_name));
+        }
+
+        // Add stream name
+        signal.push_str(self.get_source_stream_name());
+
+        // Connector
+        signal.push_str(" => ");
+
+        // If the signal is to an instance, add the instance name
+        if let Some(dest_inst_name) = self.get_dest_inst_name() {
+            signal.push_str(&format!("{}.", dest_inst_name));
+        }
+
+        // Add stream name
+        signal.push_str(self.get_dest_stream_name());
+
+        format!("{};", signal)
+    }
 }

--- a/src/analysis/types/signals.rs
+++ b/src/analysis/types/signals.rs
@@ -68,6 +68,8 @@ impl TilSignal {
         // If the signal is from an instance, add the instance name
         if let Some(source_inst_name) = self.get_source_inst_name() {
             signal.push_str(&format!("\t{}.", source_inst_name));
+        } else {
+            signal.push_str(&"self.".to_string());
         }
 
         // Add stream name
@@ -79,6 +81,8 @@ impl TilSignal {
         // If the signal is to an instance, add the instance name
         if let Some(dest_inst_name) = self.get_dest_inst_name() {
             signal.push_str(&format!("{}.", dest_inst_name));
+        } else {
+            signal.push_str(&"self.".to_string());
         }
 
         // Add stream name

--- a/src/analysis/types/signals.rs
+++ b/src/analysis/types/signals.rs
@@ -67,7 +67,7 @@ impl TilSignal {
 
         // If the signal is from an instance, add the instance name
         if let Some(source_inst_name) = self.get_source_inst_name() {
-            signal.push_str(&format!("\t{}.", source_inst_name));
+            signal.push_str(&format!("    {}.", source_inst_name));
         } else {
             signal.push_str(&"self.".to_string());
         }

--- a/src/analysis/types/streaming_interface.rs
+++ b/src/analysis/types/streaming_interface.rs
@@ -71,6 +71,10 @@ impl TilStream {
     pub fn get_type(&self) -> &StreamTypeDecl {
         &self.stream_type
     }
+
+    pub fn td(&self) -> String {
+        format!("{}: {} {};", self.get_name(), self.get_type(), self.direction)
+    }
 }
 
 impl Display for TilStream {

--- a/src/analysis/types/streaming_interface.rs
+++ b/src/analysis/types/streaming_interface.rs
@@ -131,7 +131,7 @@ impl Generic {
             GenericType::Positive(value) => *value as i64,
             GenericType::Dimensionality(value) => *value as i64
         };
-        format!("\t{} = {};\n", self.get_name(), value)
+        format!("    {} = {};\n", self.get_name(), value)
     }
 }
 

--- a/src/analysis/types/streaming_interface.rs
+++ b/src/analysis/types/streaming_interface.rs
@@ -119,6 +119,16 @@ impl Generic {
     pub fn get_type(&self) -> &GenericType {
         &self.generic_type
     }
+
+    pub fn td(&self) -> String {
+        let value = match self.get_type() {
+            GenericType::Integer(value) => *value as i64,
+            GenericType::Natural(value) => *value as i64,
+            GenericType::Positive(value) => *value as i64,
+            GenericType::Dimensionality(value) => *value as i64
+        };
+        format!("\t{} = {};\n", self.get_name(), value)
+    }
 }
 
 impl Display for Generic {

--- a/src/analysis/types/streaming_interface.rs
+++ b/src/analysis/types/streaming_interface.rs
@@ -73,7 +73,11 @@ impl TilStream {
     }
 
     pub fn td(&self) -> String {
-        format!("{}: {} {};", self.get_name(), self.get_type(), self.direction)
+        let type_dim = self.get_type().get_stream_dim();
+        if (type_dim.is_some()) {
+            return format!("{}: t{}.{} {};", self.get_name(), type_dim.as_ref().unwrap(), self.get_type().get_name(), self.direction);
+        }
+        format!("{}: t<0>.{} {};", self.get_name(), self.get_type().get_name(), self.direction)
     }
 }
 

--- a/src/analysis/types/til_streamlet.rs
+++ b/src/analysis/types/til_streamlet.rs
@@ -36,6 +36,57 @@ impl TilStreamlet {
     pub fn get_implementation(&self) -> &Option<TilImplementationType> {
         &self.implementation
     }
+
+    pub fn td (&self) -> String {
+        let mut comp_def = String::new();
+        let mut generics = String::new();
+        let mut stream_defs = String::new();
+
+        if !self.get_streams().get_generics().is_empty() {
+            let mut generic_defs = String::new();
+
+            for generic in self.get_streams().get_generics() {
+                generic_defs.push_str(
+                    &format!("{},\n", generic)
+                );
+            }
+
+            generics = formatdoc!(
+                "
+                <
+                {}
+                >",
+                generic_defs
+            );
+        }
+
+        for stream in self.get_streams().get_streams() {
+            stream_defs.push_str(
+                &format!("\t{}\n", stream.td())
+            );
+        }
+
+        comp_def.push_str(
+            &formatdoc!(
+                "streamlet {} {{\n{}}}",
+                self.get_name(),
+                // generics,
+                stream_defs
+            )
+        );
+
+        if let Some(implementation) = &self.implementation {
+            let temp_str = match implementation {
+                TilImplementationType::Path(str) => "".to_string(),
+                TilImplementationType::Inline(inline) => {
+                    inline.td(self.get_name().to_string())
+                },
+            };
+            comp_def += &temp_str;
+        }
+
+        format!("{};", comp_def)
+    }
 }
 
 impl Display for TilStreamlet {
@@ -122,6 +173,24 @@ impl TilInlineImplementation {
     pub fn get_signals(&self) -> &Vec<TilSignal> {
         &self.signals
     }
+
+    pub fn td(&self, name: String) -> String {
+        let mut impl_til = String::new();
+
+        for instance in self.get_instances() {
+            impl_til.push_str(&instance.td());
+            impl_til.push('\n');
+        }
+
+        impl_til.push_str("\n\t");
+
+        for signal in self.get_signals() {
+            impl_til.push_str(&signal.td());
+            impl_til.push('\n');
+        }
+        
+        format!("\n\nimpl {name}_impl of {name} @External {{\n{impl_til}}}")
+    }
 }
 
 impl Display for TilImplementationType {
@@ -178,6 +247,10 @@ impl TilInstance {
             component_name: String::from(component_name),
             instance_name: String::from(instance_name),
         }
+    }
+
+    pub fn td(&self) -> String {
+        format!("\t{} = {};", self.instance_name, self.component_name)
     }
 }
 

--- a/src/analysis/types/til_streamlet.rs
+++ b/src/analysis/types/til_streamlet.rs
@@ -45,19 +45,10 @@ impl TilStreamlet {
         if !self.get_streams().get_generics().is_empty() {
             let mut generic_defs = String::new();
 
-            for generic in self.get_streams().get_generics() {
-                generic_defs.push_str(
-                    &format!("{},\n", generic)
-                );
-            }
+            let str = self.get_streams().get_generics().iter().map(|e| e.td()).collect::<Vec<_>>().join("");
+            generic_defs.push_str(&str);
 
-            generics = formatdoc!(
-                "
-                <
-                {}
-                >",
-                generic_defs
-            );
+            generics = generic_defs;
         }
 
         for stream in self.get_streams().get_streams() {
@@ -68,7 +59,7 @@ impl TilStreamlet {
 
         comp_def.push_str(
             &formatdoc!(
-                "streamlet {} {{\n{}}}",
+                "streamlet {} {{\n{generics}\n{}}}",
                 self.get_name(),
                 // generics,
                 stream_defs

--- a/src/analysis/types/til_streamlet.rs
+++ b/src/analysis/types/til_streamlet.rs
@@ -53,7 +53,7 @@ impl TilStreamlet {
 
         for stream in self.get_streams().get_streams() {
             stream_defs.push_str(
-                &format!("\t{}\n", stream.td())
+                &format!("    {}\n", stream.td())
             );
         }
 
@@ -99,7 +99,7 @@ impl Display for TilStreamlet {
 
         for stream in self.get_streams().get_streams() {
             stream_defs.push_str(
-                &format!("\t{},\n", stream)
+                &format!("    {},\n", stream)
             );
         }
 
@@ -140,7 +140,7 @@ impl TilImplementationType {
                     impl_til.push('\n');
                 }
 
-                impl_til.push_str("\n\t");
+                impl_til.push_str("\n    ");
 
                 for signal in inline.get_signals() {
                     impl_til.push_str(&signal.td());
@@ -243,7 +243,7 @@ impl TilInstance {
     }
 
     pub fn td(&self) -> String {
-        format!("\tinstance {}({}_impl);", self.instance_name, self.component_name)
+        format!("    instance {}({}_impl);", self.instance_name, self.component_name)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,38 @@ fn main() {
      }
      "#;
 
+     let _student = r#"
+     {
+        "student_number": "S123456789",
+        "name": "John Doe",
+        "birthdate": "2000-05-15",
+        "study_start": "2021-05-15",
+        "study_end": null,
+        "study": "Computer Science",
+        "email": "john.doe@example.com",
+        "exams": [
+          {
+            "course_code": "CS101",
+            "course_name": "Introduction to Computer Science",
+            "exam_date": "2023-12-10",
+            "grade": 80
+          },
+          {
+            "course_code": "MATH201",
+            "course_name": "Calculus",
+            "exam_date": "2023-12-15",
+            "grade": 60
+          },
+          {
+            "course_code": "ENG101",
+            "course_name": "English Composition",
+            "exam_date": "2023-12-20",
+            "grade": 73
+          }
+        ]
+      }
+      "#;
+
     let _nested = r#"
     {
         "voltage":
@@ -30,10 +62,10 @@ fn main() {
     let visualize = true;
 
     // Create a new generator
-    let mut generator = Generator::new("schema_parser", 4, 64);
+    let mut generator = Generator::new("student_schema_parser", 4, 64);
 
     // Analyze the JSON string
-    generator.analyze(_multiple_keys).unwrap();
+    generator.analyze(_student).unwrap();
     
     if visualize {
         // Visualize the JSON string


### PR DESCRIPTION
- Update the `JSON_hierarchy` project with [TydiLang](https://github.com/twoentartian/tydi-lang-2) output.\
This is not done in the prettiest way imaginable from a code perspective, but the output is more nicely formatted than the TIL output.
  - The TL output has the advantage that TL can automatically insert the required stream duplicators between a source and multiple sinks. This was one of the limitations of the original project.
- Add a README with information about the project.
- Fix a small bug regarding the nesting level of string parsers. This was off-by-one.
- Add a more complicated example. In this case the [example for the TVLSI paper](https://github.com/ccromjongh/Tydi-TVLSI-example).